### PR TITLE
replace pyNMS with eNMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,10 +202,10 @@ Network Automation is cross between two disciplines of Infrastructure Networks a
 
 ## Products
 
+ - [eNMS](https://github.com/afourmy/eNMS) - A vendor-agnostic NMS for carrier-grade network visualization and network automation.
  - [Netshot](http://www.netfishers.onl/netshot) - Network Configuration and Compliance Management Software.
  - [NSOT](https://github.com/dropbox/nsot) - Network Source of Truth (NSoT) a source of truth database and repository for tracking inventory and metadata of network entities to ease management and automation of network infrastructure.
  - [Nuts](https://github.com/HSRNetwork/Nuts) - Network Unit Testing System automates tests in the network similar to unit tests.
- - [pyNMS](https://github.com/afourmy/pyNMS) - pyNMS is a vendor-agnostic Network Management System for network visualization, inventory and graphical automation.
  - [Rundeck](http://rundeck.org/) - Job scheduler and runbook (and Ansible playbook) automation.
  - [ToDD](https://github.com/toddproject/todd) - ToDD is an extensible framework for providing natively distributed testing on demand.
  - [Trigger](https://github.com/trigger/trigger) - Trigger is a robust network automation toolkit written in Python that was designed for interfacing with network devices and managing network configuration and security policy.


### PR DESCRIPTION
integration of NAPALM / netmiko is now part of eNMS (napalm hackathon project). I will remove the network automation NAPALM / netmiko support in pyNMS so I remove it from here too.
