### PR TITLE
add GNS3 entry to hypervisor list

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ Network Automation is cross between two disciplines of Infrastructure Networks a
 
  - Docker
  - ESX
+ - [GNS3](https://www.gns3.com/) - Graphical Network Simulator 3 allows to build virtual networks using emulated network devices, with comprehensive support for different emulation technologies
  - Kubernetes
  - Marathon
  - OpenStack


### PR DESCRIPTION
GNS3 provides a comprehensive environment to build virtual labs. A virtual lab is practically a requirement for CI/CD pipelines, and quite useful for experimenting with network automation.

The Hypervisor list currently comprises e.g. Kubernetes (more orchestration), Docker (not really a Hypervisor), and Hypervisors like VMware or VirtualBox. IMHO GNS3 fits into this group as well.

GNS3 is no longer primarily used for Dynamips, but allows to easily add different virtual network devices (called appliances in GNS3) from different vendors, e.g. Arista, Cisco, Extreme, or Juniper, among others.

Thanks,
Erik