### PR TITLE
add fetchconfig to section "Backups"

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ Network Automation is cross between two disciplines of Infrastructure Networks a
 # Backups
 
 - [Cidr](https://github.com/renard/cidr) - Cidr Is not as Dumb as Rancid.
+- [fetchconfig](https://github.com/udhos/fetchconfig) - fetchconfig is a Perl script for retrieving configuration of multiple devices
 - [Gerty](https://github.com/ssinyagin/gerty) - Universal framework for device management automation. Eventually a replacement for RANCID... and much more.
 - [Jazigo](https://github.com/udhos/jazigo) - Jazigo is a tool written in Go for retrieving configuration for multiple devices, similar to rancid, fetchconfig, oxidized, Sweet.
 - [Oxidized](https://github.com/ytti/oxidized) - Oxidized is a network device configuration backup tool. It's a RANCID replacement!


### PR DESCRIPTION
The existing entry for "Jazigo" mentions "fetchconfig," but the list
does not yet contain a link to it.

If you look at the old fetchconfig site hosted on Savannah
( http://www.nongnu.org/fetchconfig/ ) you will see that
fetchconfig is now hosted at GitHub, which is the link I add.
